### PR TITLE
Removing owl-axioms header

### DIFF
--- a/plant-trait-ontology.obo
+++ b/plant-trait-ontology.obo
@@ -16,7 +16,6 @@ import: http://purl.obolibrary.org/obo/to/imports/go_import.owl
 import: http://purl.obolibrary.org/obo/to/imports/pato_import.owl
 import: http://purl.obolibrary.org/obo/to/imports/ro_import.owl
 ontology: to
-owl-axioms: Prefix(owl:=<http://www.w3.org/2002/07/owl#>)\nPrefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)\nPrefix(xml:=<http://www.w3.org/XML/1998/namespace>)\nPrefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)\nPrefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)\n\n\nOntology(\nDeclaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#created_by>))\n\n\nAnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/TO_0000241> \"\")\nAnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#created_by> <http://purl.obolibrary.org/obo/TO_0000980> \"\")\n)
 
 [Term]
 id: TO:0000001


### PR DESCRIPTION
Removing the owl-axioms header. This contained two axioms that couldn't be translated to .obo:

 * TO_0000241 had an rdfs:comment that was an empty string
 * TO_0000980 had a created_by that was an empty string

These were presumably unintentional/errors

It seems the owl->obo converter refuses to convert empty-string fields, which forces them into the OWL header (http://owlcollab.github.io/oboformat/doc/obo-syntax.html#5.04)

This is not itself a problem normally, but until https://github.com/protegeproject/protege/issues/501 is fixed, the file cannot be saved in obo from protege