### PR TITLE
[WIP] OBO format version 1.4 compliance

### DIFF
--- a/plant-trait-ontology.obo
+++ b/plant-trait-ontology.obo
@@ -1150,7 +1150,7 @@ is_a: TO:0000371 ! yield trait
 [Term]
 id: TO:0000144
 name: milled rice yield
-def: "A grain yield trait (TO:0000396) which is the proportion of kernels remaining after milling to remove the bran." [RiceCAP https://ricecap.hosted.uark.edu/glossary_ricecaplist.htm#M]
+def: "A grain yield trait (TO:0000396) which is the proportion of kernels remaining after milling to remove the bran." [https://ricecap.hosted.uark.edu/glossary_ricecaplist.htm#M]
 comment: Milling is part of rice processing where the caryopsis hull (PO:0006000) and bran is removed. Milled rice consists of the broken kernels as well as the head rice (whole or 3/4 of original length or longer) milled kernels.
 synonym: "milled rice ratio (related)" RELATED []
 synonym: "MR (related)" RELATED []

--- a/plant-trait-ontology.obo
+++ b/plant-trait-ontology.obo
@@ -1856,7 +1856,7 @@ is_a: TO:0002717 ! leaf sheath auricle morphology trait
 [Term]
 id: TO:0000227
 name: root length
-def: "A root morphology trait (TO:0000043) which is the length of a root (PO:0009005)." [Gramene:jcl\nGR\:pj, TO:austin_meier\nTO\:cooperl]
+def: "A root morphology trait (TO:0000043) which is the length of a root (PO:0009005)." [Gramene:jcl, GR:pj, TO:austin_meier, TO:cooperl]
 comment: refer to PATO:0000122- A 1-D extent quality which is equal to the distance between two points.
 synonym: "maximum root depth (related)" RELATED []
 synonym: "maximum root length (related)" RELATED []

--- a/plant-trait-ontology.obo
+++ b/plant-trait-ontology.obo
@@ -11862,7 +11862,7 @@ creation_date: 2011-08-19T01:07:39Z
 [Term]
 id: TO:0020070
 name: beta-glucanase activity trait
-def: "Activity of beta-glucanase ((1,3-1,4)-beta-D-glucan, 4-glucanohydrolase), (EC:3.2.1.73) in the hydrolysis of beta-glucans." [GO:0042972, GO:\:0052736, T-CAP:Victoria_Corollo_Blake]
+def: "Activity of beta-glucanase ((1,3-1,4)-beta-D-glucan, 4-glucanohydrolase), (EC:3.2.1.73) in the hydrolysis of beta-glucans." [GO:0042972, GO:0052736, T-CAP:Victoria_Corollo_Blake]
 is_a: TO:0000599 ! enzyme activity trait
 created_by: jaiswalp
 creation_date: 2011-08-19T01:10:26Z

--- a/plant-trait-ontology.obo
+++ b/plant-trait-ontology.obo
@@ -4270,7 +4270,7 @@ is_a: TO:0000566 ! leaf stomatal complex frequency
 [Term]
 id: TO:0000531
 name: anther length
-def: "An anther morphology trait (TO:1000022) which is the length (PATO:0000122) of an anther (PO:0009066)." [TO:ethan_johnson\nTO\:austin_meier]
+def: "An anther morphology trait (TO:1000022) which is the length (PATO:0000122) of an anther (PO:0009066)." [TO:ethan_johnson, TO:austin_meier]
 comment: Refers to length (PATO:0000122): A 1-D extent quality which is equal to the distance between two points.
 synonym: "ANTLG (related)" RELATED []
 xref: TO_GIT:385

--- a/plant-trait-ontology.obo
+++ b/plant-trait-ontology.obo
@@ -5767,7 +5767,7 @@ is_a: TO:0000719 ! leaf vein color
 [Term]
 id: TO:0000721
 name: leaf adherence
-def: "A leaf morphology trait (TO:0000748) which is a tightly rolled leaf encasing the next emerging leaf (PO:0025034)." [Gramene:pankaj_jaiswal, PO:0025034\,TO\:cooperl]
+def: "A leaf morphology trait (TO:0000748) which is a tightly rolled leaf encasing the next emerging leaf (PO:0025034)." [Gramene:pankaj_jaiswal, PO:0025034, TO:cooperl]
 comment: If you are annotating to this term, please add an additional annotation to vascular leaf morphology (TO:0000419) or non-vascular leaf morphology trait (TO:0000925), depending on the species.
 is_a: TO:0000748 ! leaf morphology trait
 

--- a/plant-trait-ontology.obo
+++ b/plant-trait-ontology.obo
@@ -4715,7 +4715,7 @@ is_a: TO:0000920 ! infructescence morphology trait
 [Term]
 id: TO:0000586
 name: seminal root length
-def: "A root length (TO:0000227) that is the length of one or more seminal roots (PO:0000046)." [Gramene:pankaj_jaiswal37, TO:seymour_megan\nTO\:austin_meier]
+def: "A root length (TO:0000227) that is the length of one or more seminal roots (PO:0000046)." [Gramene:pankaj_jaiswal37, TO:seymour_megan, TO:austin_meier]
 comment: Seminal root is the primary root originating in a plant after germination.\nRefer to length (PATO:0000122): A 1-D extent quality which is equal to the distance between two points.
 xref: PATO:0000122
 xref: TO_GIT:365

--- a/plant-trait-ontology.obo
+++ b/plant-trait-ontology.obo
@@ -242,7 +242,7 @@ is_a: TO:0000080 ! micronutrient sensitivity
 [Term]
 id: TO:0000030
 name: sedge weed
-def: "A common sedge weed Cyperus iria (rice flatsedge), Cyperus difformis (Small flower umbrella sedge),  Rice field bulrush Scirpus mucronatus, River bulrush Scirpus fluviatilis. Grows as a weed in the rice field. Can be distinguished from grass plant by the leaf shape, venation, stem cross-section and plant shape leaf shape." [Gramene:pankaj_jaiswal, ISBN:9712200299, web:http//www.ipm.ucdavis.edu/PMG/r682700999.html]
+def: "A common sedge weed Cyperus iria (rice flatsedge), Cyperus difformis (Small flower umbrella sedge),  Rice field bulrush Scirpus mucronatus, River bulrush Scirpus fluviatilis. Grows as a weed in the rice field. Can be distinguished from grass plant by the leaf shape, venation, stem cross-section and plant shape leaf shape." [Gramene:pankaj_jaiswal, ISBN:9712200299, http//www.ipm.ucdavis.edu/PMG/r682700999.html]
 is_a: TO:0000347 ! weed damage
 
 [Term]
@@ -804,7 +804,7 @@ is_a: TO:0000587 ! endosperm quality
 [Term]
 id: TO:0000101
 name: broad-leaved weed
-def: "A common sedge weed Monochoria vaginalis (monochoria), California arrowhead Sagittaria montevidensis, Gregg arrowhead Sagittaria longiloba, Ducksalad Heteranthera limosa, Echinodorus berteroi and E. cordifolius (Burhead), Ammannia spp (Redstems), Bacopa spp. (Water hyssops), Alisma plantago-aquatica (Common water plantain). Grows as a weed in the rice field. Can be distinguished from rice plant by the leaf shape, venation, stem cross-section and plant shape leaf shape." [Gramene:pankaj_jaiswal, ISBN:9712200299, web:http//www.ipm.ucdavis.edu/PMG/r682700999.html]
+def: "A common sedge weed Monochoria vaginalis (monochoria), California arrowhead Sagittaria montevidensis, Gregg arrowhead Sagittaria longiloba, Ducksalad Heteranthera limosa, Echinodorus berteroi and E. cordifolius (Burhead), Ammannia spp (Redstems), Bacopa spp. (Water hyssops), Alisma plantago-aquatica (Common water plantain). Grows as a weed in the rice field. Can be distinguished from rice plant by the leaf shape, venation, stem cross-section and plant shape leaf shape." [Gramene:pankaj_jaiswal, ISBN:9712200299, http://www.ipm.ucdavis.edu/PMG/r682700999.html]
 is_a: TO:0000347 ! weed damage
 
 [Term]
@@ -2218,7 +2218,7 @@ is_obsolete: true
 [Term]
 id: TO:0000273
 name: armyworm resistance
-def: "Causal agent: Pseudaletia unipuncta, Spodoptera mauritia and Spodoptera praefica. The swarming caterpillars cause severe damage to rice plants in nursery beds." [Gramene:pankaj_jaiswal, web:http//pne.gsnu.ac.kr/riceipm/spodopte.htm, web:http//www.ipm.ucdavis.edu/PMG/r682300411.html]
+def: "Causal agent: Pseudaletia unipuncta, Spodoptera mauritia and Spodoptera praefica. The swarming caterpillars cause severe damage to rice plants in nursery beds." [Gramene:pankaj_jaiswal, http://pne.gsnu.ac.kr/riceipm/spodopte.htm, http://www.ipm.ucdavis.edu/PMG/r682300411.html]
 comment: The worms appear suddenly in masses and move like an army from field to field so that seedbeds or the direct seeded fields look as if grazed by cattles. Generally, a transplanted crop is not severely affected. Damage by armyworms is most serious during periods of stem elongation and grain formation. Larvae defoliate plants, typically by chewing angular pieces off leaves. They may also feed on the panicle near the developing kernels causing these kernels to dry before filling. This feeding causes all or parts of the panicle to  turn white. If the entire panicle is white, the damage may also be due to stem rot or feeding by rats. The  seriousness of armyworm injury depends on the maturity of the plant and the amount of tissue consumed. Significant yield reduction can occur if defoliation is greater than 25% at 2 to 3 weeks before heading. They migrate from field to field and extensive losses are often caused within a week. Their migration is facilitated by the absence of standing water in the field.
 synonym: "AWRRS (related)" RELATED []
 is_a: TO:0000261 ! insect damage resistance
@@ -2835,7 +2835,7 @@ is_a: TO:0000270 ! inflorescence axis angle
 [Term]
 id: TO:0000343
 name: grass weed
-def: "A common grass weed Echinochloa glabbrescens or Echinochloa crus-galli (Barnyard grass), Typha spp. (Cattails), Leptochloa fascicularis (Bearded sprangletop) grows as a weed in the rice field. Can be distinguished from rice plant by the leaf shape, venation, stem cross-section and plant shape leaf shape." [Gramene:pankaj_jaiswal, ISBN:9712200299, www:http//www.ipm.ucdavis.edu/PMG/r682700999.html]
+def: "A common grass weed Echinochloa glabbrescens or Echinochloa crus-galli (Barnyard grass), Typha spp. (Cattails), Leptochloa fascicularis (Bearded sprangletop) grows as a weed in the rice field. Can be distinguished from rice plant by the leaf shape, venation, stem cross-section and plant shape leaf shape." [Gramene:pankaj_jaiswal, ISBN:9712200299, http://www.ipm.ucdavis.edu/PMG/r682700999.html]
 is_a: TO:0000347 ! weed damage
 
 [Term]
@@ -3392,7 +3392,7 @@ is_a: TO:0001069 ! cooking quality trait
 [Term]
 id: TO:0000413
 name: rice tungro virus resistance
-def: "Causal agent: Rice tungro bacilliform virus (RTBV) and rice tungro spherical virus (RTSV). The disease is transmitted by the green leafhopper Nephotettix spp. Symptoms: Yellow-to-yellow orange leaves, stunting and slightly reduced tillering." [Gramene:pankaj_jaiswal, IRRI:SES, web:http//www.fao.org/inpho/vlibrary/t0567e/T0567E03.htm]
+def: "Causal agent: Rice tungro bacilliform virus (RTBV) and rice tungro spherical virus (RTSV). The disease is transmitted by the green leafhopper Nephotettix spp. Symptoms: Yellow-to-yellow orange leaves, stunting and slightly reduced tillering." [Gramene:pankaj_jaiswal, IRRI:SES, http://www.fao.org/inpho/vlibrary/t0567e/T0567E03.htm]
 synonym: "RTD (related)" RELATED []
 synonym: "RTVRS (related)" RELATED []
 is_a: TO:0000148 ! viral disease resistance
@@ -3820,7 +3820,7 @@ is_a: TO:0000465 ! mineral and ion content trait
 [Term]
 id: TO:0000467
 name: cell membrane stability
-def: "Stability of the cell membrane under the impact of temperature (heat) and water deficit stress." [Gramene:pankaj_jaiswal, web:http\://www.plantstress.com/methods/CMS_method.htm]
+def: "Stability of the cell membrane under the impact of temperature (heat) and water deficit stress." [Gramene:pankaj_jaiswal, http://www.plantstress.com/methods/CMS_method.htm]
 comment: The trait is often observed in plants as a measure of drought and heat tolerance by determining the amount of solutes/electrolyte leaked from the cell.
 synonym: "CELMBSTB (related)" RELATED []
 is_a: TO:0000168 ! abiotic stress trait
@@ -9644,7 +9644,7 @@ is_obsolete: true
 [Term]
 id: TO:0002641
 name: acid detergent fiber
-def: "The percentage of highly indigestible or slowly digestible fiber in a feed or forage. Acid detergent fiber contains cellulose as well as silica and lignin which are associated with low digestibility." [GrainGenes_trait:Acid_Detergent_Fiber, Gramene:pankaj_jaiswal, web:http\://www.foragetesting.org/lab_procedure/sectionB/4/part4.1.htm]
+def: "The percentage of highly indigestible or slowly digestible fiber in a feed or forage. Acid detergent fiber contains cellulose as well as silica and lignin which are associated with low digestibility." [GrainGenes_trait:Acid_Detergent_Fiber, Gramene:pankaj_jaiswal, http://www.foragetesting.org/lab_procedure/sectionB/4/part4.1.htm]
 comment: The method typically uses acidified quaternary detergent solution to dissolve cell solubles, hemicellulose and soluble minerals leaving a residue of cellulose, lignin, and heat damaged protein and a portion of cell wall protein and minerals (ash). Acid detergent fiber is determined gravimetrically as the residue remaining after extraction. The lower the acid detergent fiber, the more digestible the feed is and the higher the energy value of the feed.
 synonym: "ACIDDETFIBR (related)" RELATED []
 synonym: "ADF (related)" RELATED []
@@ -10349,7 +10349,7 @@ is_a: TO:0002718 ! awn morphology trait
 [Term]
 id: TO:0002735
 name: straighthead
-def: "Malformed inflorescence (panicle in rice), by staying upright/straight at the time of maturity and may carry infertile seeds." [Gramene:pankaj_jaiswal, web:http\://plantpathology.tamu.edu/Texlab/Grains/Rice/rices.html]
+def: "Malformed inflorescence (panicle in rice), by staying upright/straight at the time of maturity and may carry infertile seeds." [Gramene:pankaj_jaiswal, http://plantpathology.tamu.edu/Texlab/Grains/Rice/rices.html]
 comment: For rice: Straighthead is a physiological disorder that causes the entire head to be blank and remain upright at maturity in rice. Straighthead generally occurs in spots scattered throughout a field and is most easily recognized near harvest when normal plants have downturned heads (from the weight of the grain in the panicle). The disease is frequently found on sandy loam soils but seldom on clay soils. Old cotton fields with arsenic residues can have a severe incidence of straighthead. Other, as yet unknown, soil factors are also involved in causing straighthead. Often it is found in fields where excessive non-decayed vegetation has been plowed under just before planting. The disease is characterized by upright heads when the rice matures due to infertile seed. Hulls may be distorted into a crescent shape or "parrot beak". One or both hulls may be missing. Affected plants continue to grow, are a darker green, and often produce shoots from a lower portion of the plant. First year crops of rice grown on "new ground" are more likely to be affected. Some varieties are more tolerant than others. Control measures include planting resistant varieties and draining fields with a history of the disorder just prior to internode elongation.
 is_a: TO:0000373 ! inflorescence morphology trait
 

--- a/plant-trait-ontology.obo
+++ b/plant-trait-ontology.obo
@@ -2544,7 +2544,7 @@ is_a: TO:0000497 ! fertility restoration trait
 [Term]
 id: TO:0000310
 name: self-incompatibility
-def: "Self-incompatibility allows plants to recognize and reject pollen from the same plant, thereby reducing inbreeding." [PubMed:PMID_10066554]
+def: "Self-incompatibility allows plants to recognize and reject pollen from the same plant, thereby reducing inbreeding." [PMID:10066554]
 comment: In most cases self-incompatibility is controlled by a single genetic locus, recent results show that complex signal transduction pathways and many players are involved in pollen recognition and rejection.
 synonym: "Genetic self-incompatibility (related)" RELATED []
 is_a: TO:0000035 ! incompatibility trait


### PR DESCRIPTION
Hi !

This PR addresses some issues in the plant trait ontology to make it compliant with the OBO 1.4 specification. It also brings some suggestions to improve the contents and interoperability of the ontology itself. (cc @cmungall)

# Required changes
- [x] Fix invalid xref in `TO:0000144`

# Optional fixes
- [x] Fix invalid quotes in `replaced_by` clause of `TO:0012003`.
- [x] Fix PMID in `TO:0000310`
- [x] Fix some xref being merged (several IDs merged together).
- [x] Remove `www` and `web` prefixes since plain URLs are valid xref identifiers.


# Suggested changes
### Use ORCIDs to refer to people instead of using project prefixes
The semantics of database xrefs is not completely clear, but the format specification recommends to use a prefix catalog such as [`db-xref.yaml`](https://github.com/geneontology/go-site/blob/master/metadata/db-xrefs.yaml) to resolve the prefixed IDs into URIs. In TO however, I assume prefixes are used to indicate the group individuals belong to (such as `TO:cooperl` or `Gramene:pankaj_jaiswal`). This may lead automatic IRI expansion of theses xrefs to produce invalid URLs, since `cooperl` is expected to be an entity of `TO`.

### Define IDspace for `TO_GIT`
Having a reference to an GitHub issue for a term added by the community is a super good practice, but the URL to the issue can't be resolved automatically because the `TO_GIT` prefix is not defined formally. This can be fixed simply by adding the following clause to the header frame:
```ini
idspace: TO_GIT "https://github.com/Planteome/plant-trait-ontology/issues/"
```

Or even better, use a PURL to the tracker as it is the convention for many OBO ontologies:
```ini
idspace: TO_GIT "http://purl.obolibrary.org/obo/to/tracker/"
```
(which would require a new PURL handler to be added to `purl.obolibrary.org` but that's fairly easy to do).

Then, `TO_GIT:54` would expand to `https://github.com/Planteome/plant-trait-ontology/issues/54`.


### Remove redundancy in synonym definitions

Since synonym scopes are explicitly given, there is no need to add them to the synonym definition (e.g. `synonym: "CW (related)" RELATED []` should just be `synonym: "CW" RELATED []`) because annotation software would probably not sanitize the synonym name, possibly causing some synonyms not to be detected.