### PR TITLE
Replace date syntax on 2020-09-16 entry

### DIFF
--- a/to.obo
+++ b/to.obo
@@ -26925,7 +26925,7 @@ def: "An essential fatty acid (TO:0000604) content which is the amount of a poly
 comment: There are two forms of linolenic acid, alpha and gamma, depending upon where the double bonds occur.
 is_a: TO:0000604 ! fat and essential oil content
 created_by: Laurel_Cooper
-creation_date: 2020-09-16
+creation_date: 2020-09-16T00:00:00Z
 
 [Term]
 id: TO:1000075
@@ -26934,7 +26934,7 @@ def: "A fatty acid content (TO:0000604) which is the amount of a straight-chain,
 synonym: "hexadecanoic acid (exact)" EXACT []
 is_a: TO:0000604 ! fat and essential oil content
 created_by: Laurel_Cooper
-creation_date: 2020-09-16
+creation_date: 2020-09-16T00:00:00Z
 
 [Typedef]
 id: evaluation_location


### PR DESCRIPTION
My parser chokes on the date entry "2020-09-16" by Laurel Cooper for TO:1000074 and TO:1000075 (terms which I coincidentally use!) I've updated them with the format that pleases my parser (used by InterMine): 2020-09-16T00:00:00Z