### PR TITLE
Removed space in TO: Laurel Cooper in OWL and OBO files.

### DIFF
--- a/to.obo
+++ b/to.obo
@@ -14891,7 +14891,7 @@ is_a: TO:0000148 ! viral disease response
 [Term]
 id: TO:0000148
 name: viral disease response
-def: "A microbial disease response (TO:0000112) trait which is the response to damage to a plant structure (PO:0009011) caused by an infection by a virus (NCBITaxon:10239)." [Gramene:pankaj_jaiswal, NCBITaxon:10239, RiceSES:SES, TO: Laurel_Cooper]
+def: "A microbial disease response (TO:0000112) trait which is the response to damage to a plant structure (PO:0009011) caused by an infection by a virus (NCBITaxon:10239)." [Gramene:pankaj_jaiswal, NCBITaxon:10239, RiceSES:SES, TO:Laurel_Cooper]
 comment: It represents the damage done by the diease and/or the viral pathogen to the plant. The damage is a direct measure of resistance to the particular viral strain causing the diease.
 is_a: TO:0000112 ! microbial disease response
 

--- a/to.owl
+++ b/to.owl
@@ -32979,7 +32979,7 @@ Common sedge weeds in rice fields include Smallflower Umbrella Sedge (Cyperus di
         <oboInOwl:hasDbXref>Gramene:pankaj_jaiswal</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>NCBITaxon:10239</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>RiceSES:SES</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref>TO: Laurel_Cooper</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>TO:Laurel_Cooper</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 


### PR DESCRIPTION
Space in TO: Laurel Cooper caused issues while using pronto. First identified here: https://github.com/althonos/pronto/issues/243#event-1736158882501